### PR TITLE
Add GitHub action to generate LSIF for Go repositories

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -1,0 +1,17 @@
+name: LSIF
+on:
+    - push
+jobs:
+    lsif-go:
+        runs-on: ubuntu-latest
+        container: sourcegraph/lsif-go
+        steps:
+            - uses: actions/checkout@v1
+            - name: Generate LSIF data
+              run: lsif-go
+            - name: Upload LSIF data
+              run: src lsif upload
+              env:
+                SRC_ACCESS_TOKEN: http://localhost:80
+                SRC_ENDPOINT: 0bea1b42a0445a6a6f2dcb37b2c5db7f8600dd34
+


### PR DESCRIPTION
Adds a GitHub action that generates LSIF for all Go repositories (selected by the query `file:go.mod$ fork:yes` on this Sourcegraph instance.

[_Created by Sourcegraph batch change `jasonhawkharris/lsif-for-go`._](http://127.0.0.1:3080/users/jasonhawkharris/batch-changes/lsif-for-go)